### PR TITLE
Preserve symlinks when copying directory

### DIFF
--- a/truffleHog3/cli.py
+++ b/truffleHog3/cli.py
@@ -27,7 +27,7 @@ def run(**kwargs):
         if args.no_history:
             source = args.source.split("://")[-1]
             if os.path.isdir(source):
-                dir_util.copy_tree(source, tmp)
+                dir_util.copy_tree(source, tmp, preserve_symlinks=True)
             else:
                 shutil.copy2(source, tmp)
         else:


### PR DESCRIPTION
Prevents a `distutils.errors.DistutilsFileError: can't copy '...': doesn't exist or not a regular file` error when a symlink is pointing to a non-existent file.