### PR TITLE
Prevent cli rules default from overriding config rules

### DIFF
--- a/truffleHog3/cli.py
+++ b/truffleHog3/cli.py
@@ -4,7 +4,6 @@
 import argparse
 import git
 import os
-import re
 import shutil
 import sys
 
@@ -84,7 +83,7 @@ def get_cmdline_args():
     )
     parser.add_argument(
         "-r", "--rules", help="ignore default regexes and source from json",
-        dest="rules", type=argparse.FileType("r"), default=core.DEFAULT_RULES
+        dest="rules", type=argparse.FileType("r"), default=argparse.SUPPRESS
     )
     parser.add_argument(
         "-o", "--output", help="write report to file",


### PR DESCRIPTION
The default for `--rules` was overwriting the value in the config file with this update:
```
core.config.update(**args.__dict__)
```

The default is already being set in core.py when _Config is initialized.