### PR TITLE
fix relative path logic to always return correct filepaths

### DIFF
--- a/truffleHog3/lib/source.py
+++ b/truffleHog3/lib/source.py
@@ -47,15 +47,14 @@ class Simple(Engine):
                 if d.startswith(".") or self.skip(d):
                     dirs.remove(d)
 
-            relative_path = root.replace(self.path, "")
             for file in files:
-                filepath = os.path.join(relative_path, file)
-                realpath = os.path.realpath(os.path.join(root, file))
-                if self.skip(filepath):
+                filepath = os.path.join(root, file)
+                relative_path = os.path.relpath(filepath, self.path)
+                if self.skip(relative_path):
                     continue
 
                 try:
-                    with open(realpath) as f:
+                    with open(filepath) as f:
                         data = f.read()
                 except Exception as error:  # pragma: no cover
                     log.warning(f"error reading '{filepath}': {error}")
@@ -63,7 +62,7 @@ class Simple(Engine):
 
                 yield {
                     "date": _NOW,
-                    "path": filepath,
+                    "path": relative_path,
                     "branch": None,
                     "commit": None,
                     "commitHash": None,


### PR DESCRIPTION
Fixes #17 by always file paths relative to the target directory.

To reproduce, create the following directory structure:
```
mkdir -p demo/b
echo '-----BEGIN RSA PRIVATE KEY-----' > demo/a
echo '-----BEGIN RSA PRIVATE KEY-----' > demo/b/c
```

Run trufflehog and observe the following output:
```
root@659cafa5e77b:/tmp# trufflehog3 --format=json demo/
[
  {
    "date": "2020-12-10 04:33:19",
    "path": "a",
    "branch": null,
    "commit": null,
    "commitHash": null,
    "reason": "RSA private key",
    "stringsFound": [
      "-----BEGIN RSA PRIVATE KEY-----"
    ]
  },
  {
    "date": "2020-12-10 04:33:19",
    "path": "b/c",
    "branch": null,
    "commit": null,
    "commitHash": null,
    "reason": "RSA private key",
    "stringsFound": [
      "-----BEGIN RSA PRIVATE KEY-----"
    ]
  }
]
```