### PR TITLE
Add Repo_URL to output

### DIFF
--- a/truffleHog3/lib/render.py
+++ b/truffleHog3/lib/render.py
@@ -24,11 +24,12 @@ class _colors:
 
 
 _TEXT_TEMPLATE = """~~~~~~~~~~~~~~~~~~~~~%s
-Reason: {reason}
-Path:   {path}
-Branch: {branch}
-Commit: {commit}
-Hash:   {commitHash}
+Reason:    {reason}
+Path:      {path}
+Repo_URL:  {repo_url}
+Branch:    {branch}
+Commit:    {commit}
+Hash:      {commitHash}
 %s{strings}
 ~~~~~~~~~~~~~~~~~~~~~"""
 

--- a/truffleHog3/lib/source.py
+++ b/truffleHog3/lib/source.py
@@ -41,6 +41,14 @@ class Engine(ABC):
 
 
 class Simple(Engine):
+    def __init__(
+        self,
+        path: str,
+        **kwargs,
+    ):
+        self.repo = git.Repo(path)
+        super().__init__(path, **kwargs)
+
     def __iter__(self) -> MetaGen:
         for root, dirs, files in os.walk(self.path):
             for d in dirs:
@@ -63,6 +71,7 @@ class Simple(Engine):
                 yield {
                     "date": _NOW,
                     "path": relative_path,
+                    "repo_url": self.repo.remotes.origin.url,
                     "branch": None,
                     "commit": None,
                     "commitHash": None,
@@ -130,6 +139,7 @@ class Git(Engine):
                 "date": date.strftime(_FMT),
                 "path": path,
                 "branch": branch.name,
+                "repo_url": self.repo.remotes.origin.url,
                 "commit": commit.message,
                 "commitHash": commit.hexsha,
                 "data": pdiff,

--- a/truffleHog3/rules.yaml
+++ b/truffleHog3/rules.yaml
@@ -36,3 +36,8 @@ Square OAuth Secret: "sq0csp-[0-9A-Za-z\\-_]{43}"
 Twilio API Key: "SK[0-9a-fA-F]{32}"
 Twitter Access Token: "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*[1-9][0-9]+-[0-9a-zA-Z]{40}"
 Twitter OAuth: '[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*[''|"][0-9a-zA-Z]{35,44}[''|"]'
+
+# Additional rules based on @PaperMtn (https://github.com/PaperMtn)
+Azure API Tokens: (?i)('|"){0,2}(refreshtoken|accesstoken|_clientId)('|"){0,2}:(\s*)('|"){0,2}([0-9a-zA-Z!@#$&()\/\-`_.+,"]{20,})('|"){0,2}
+Generic Access Token: (?i)('|\"){0,2}access_token('|\"){0,2}:(\s*)('|\"){0,2}([0-9a-zA-Z!@#$&()\/\-`_.+,\"]{30,})('|\"){0,2}
+Password: (?i)(password\s*[`=:\"]+\s*[^\s]+|password is\s*[`=:\"]*\s*[^\s]+|pwd\s*[`=:\"]*\s*[^\s]+|passwd\s*[`=:\"]+\s*[^\s]+)


### PR DESCRIPTION
When running trufflehog3 against a number of public repos to ingest into an ES index it comes handy if you can easily review the repo_url to easily trigger alert pipelines.

I could not see other references and tested against `text` and `json` output which both worked fine.