### PR TITLE
#43: Use read_bytes to preserve correct line numbering

### DIFF
--- a/trufflehog3/models.py
+++ b/trufflehog3/models.py
@@ -140,7 +140,7 @@ class File(Model):
             return self._content
 
         try:
-            return Path(self._real or self.path).read_text()
+            return Path(self._real or self.path).read_bytes()
         except Exception as e:  # pragma: no cover
             log.warning(f"skipping file '{self.path}': {e}")
             return ""


### PR DESCRIPTION
Not yet clear for me why behavior looks better with read_bytes. but extensive tests show that line numbering is correct now.